### PR TITLE
(feat) Per-Route Rate Limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,49 @@ export default defineTask({
 ```
 Make sure to configure `ipTTL` in your `nuxt.config.ts` under `nuxtApiShield` if you wish to use a value different from the default (7 days). Setting `ipTTL: 0` (or any non-positive number) in your config will disable this cleanup task. The `RateLimit` type should be available via `#imports` if your module exports it or makes it available to Nuxt's auto-import system.
 
+## Per-Route Rate Limiting
+
+`nuxt-api-shield` supports **per-route rate limiting**, allowing you to define custom limits for specific API endpoints while keeping a global default configuration for all other routes.
+
+This is useful when certain endpoints (such as `/api/login`, `/api/auth`, or `/api/payment`) require stricter protection.
+
+---
+
+### Configuration Example
+
+The `routes` option accepts a mixed array:
+
+- **String:** applies the **global rate limit configuration**
+- **Object:** applies **custom per-route limits**
+
+```ts
+export default defineNuxtConfig({
+  modules: ['nuxt-api-shield'],
+
+  nuxtApiShield: {
+    limit: {
+      max: 12,
+      duration: 108,
+      ban: 3600
+    },
+
+    routes: [
+      // 1. String: uses the global default limit
+      '/api/example',
+
+      // 2. Object: custom rate limit for a specific route
+      {
+        path: '/api/example-per-route',
+        max: 5,       // custom max requests
+        duration: 10  // custom duration (seconds)
+        // ⚠️ "ban" always uses the global value
+      }
+    ],
+  }
+})
+```
+
+
 ## Important Considerations
 
 ### Data Privacy (IP Address Storage)

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -23,6 +23,14 @@ export default defineNuxtConfig({
       duration: 10,
       ban: 30,
     },
+    routes: [
+      '/api/example',
+      {
+        path: '/api/example-per-route',
+        max: 5,
+        duration: 10,
+      },
+    ],
     delayOnBan: true,
     retryAfterHeader: true,
     log: {

--- a/playground/server/api/example-per-route.get.ts
+++ b/playground/server/api/example-per-route.get.ts
@@ -1,0 +1,3 @@
+export default defineEventHandler(async () => {
+  return { result: 'Hello World !' }
+})

--- a/src/module.ts
+++ b/src/module.ts
@@ -6,20 +6,7 @@ import {
   addServerImports,
 } from '@nuxt/kit'
 import defu from 'defu'
-import type { LogEntry } from './runtime/server/types/LogEntry'
-
-export interface ModuleOptions {
-  limit: {
-    max: number
-    duration: number
-    ban: number
-  }
-  delayOnBan: boolean
-  errorMessage: string
-  retryAfterHeader: boolean
-  log?: LogEntry
-  routes: string[]
-}
+import type { ModuleOptions } from './type'
 
 export default defineNuxtModule<ModuleOptions>({
   meta: {

--- a/src/runtime/server/utils/createKey.ts
+++ b/src/runtime/server/utils/createKey.ts
@@ -1,0 +1,25 @@
+type CreateKeyArgs = {
+  ipAddress: string
+  prefix?: string
+  path?: string
+}
+
+/**
+ * Builds a namespaced storage key for rate-limiting operations.
+ *
+ * @param options - Object containing key generation parameters.
+ * @returns A formatted storage key string.
+ */
+const createKey = (options: CreateKeyArgs) => {
+  const args = Object.assign({}, {
+    prefix: 'ip',
+  }, options)
+
+  if (args.path) {
+    return `${args.prefix}:${args.path}:${args.ipAddress}`
+  }
+
+  return `${args.prefix}:${args.ipAddress}`
+}
+
+export default createKey

--- a/src/runtime/server/utils/routes.ts
+++ b/src/runtime/server/utils/routes.ts
@@ -1,0 +1,39 @@
+import type { LimitConfiguration, ModuleOptions } from '~/src/type'
+
+/**
+ * Extract from config route path
+ * @param routes contains array of route configuration
+ */
+export function extractRoutePaths(routes: Array<string | { path: string }>): string[] {
+  return routes.map((route) => {
+    if (typeof route === 'string') {
+      return route
+    }
+    return route.path
+  })
+}
+
+/**
+ * This function merges the global `limit` configuration with the per-route
+ *
+ * @param path - pathname from event
+ * @param config - The module configuration containing global and per-route settings.
+ * @returns The merged rate limit configuration for the route.
+ */
+export function getRouteLimit(path: string, config: ModuleOptions): LimitConfiguration {
+  return Object.assign({}, config.limit, config.routes?.find(route =>
+    typeof route !== 'string' && route.path === path,
+  ) ?? {})
+}
+
+/**
+ * Checks route path has a custom per-route limit defined.
+ * @param path - pathname to check.
+ * @param config - The module configuration containing route definitions.
+ * @returns True if a matching custom route limit exists, false otherwise.
+ */
+export function hasRouteLimit(path: string, config: ModuleOptions): boolean {
+  return config.routes?.find(route =>
+    typeof route !== 'string' && route.path === path,
+  ) !== undefined
+}

--- a/src/type.d.ts
+++ b/src/type.d.ts
@@ -1,0 +1,20 @@
+import type { LogEntry } from './runtime/server/types/LogEntry'
+
+export interface LimitConfiguration {
+  max: number
+  duration: number
+  ban: number
+}
+
+export interface RouteLimitConfiguration extends Partial<LimitConfiguration> {
+  path: string
+}
+
+export interface ModuleOptions {
+  limit: LimitConfiguration
+  delayOnBan: boolean
+  errorMessage: string
+  retryAfterHeader: boolean
+  log?: LogEntry
+  routes: Array<string | RouteLimitConfiguration>
+}

--- a/test/fixtures/withPerRouteLimit/app.vue
+++ b/test/fixtures/withPerRouteLimit/app.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>withPerRouteLimit</div>
+</template>
+
+<script setup></script>

--- a/test/fixtures/withPerRouteLimit/nuxt.config.ts
+++ b/test/fixtures/withPerRouteLimit/nuxt.config.ts
@@ -1,0 +1,33 @@
+import nuxtApiShield from '../../../src/module'
+
+export default defineNuxtConfig({
+  modules: [nuxtApiShield],
+  nitro: {
+    storage: {
+      shield: {
+        // driver: "memory",
+        driver: 'fs',
+        base: '_testWithRoutesLimiteShield',
+      },
+    },
+  },
+  nuxtApiShield: {
+    limit: {
+      max: 2,
+      duration: 3,
+      ban: 10,
+    },
+    errorMessage: 'Wait ! Something went wrong',
+    retryAfterHeader: true,
+    log: { path: '', attempts: 0 },
+    routes: [
+      '/api/example',
+      {
+        path: '/api/example-specific-limit',
+        max: 1,
+        duration: 2,
+        ban: 50,
+      },
+    ],
+  },
+})

--- a/test/fixtures/withPerRouteLimit/package.json
+++ b/test/fixtures/withPerRouteLimit/package.json
@@ -1,0 +1,5 @@
+{
+  "private": true,
+  "name": "withroutes",
+  "type": "module"
+}

--- a/test/fixtures/withPerRouteLimit/server/api/example-specific-limit.get.ts
+++ b/test/fixtures/withPerRouteLimit/server/api/example-specific-limit.get.ts
@@ -1,0 +1,3 @@
+export default defineEventHandler(async () => {
+  return { id: 2, name: 'Radha' }
+})

--- a/test/fixtures/withPerRouteLimit/server/api/example.get.ts
+++ b/test/fixtures/withPerRouteLimit/server/api/example.get.ts
@@ -1,0 +1,3 @@
+export default defineEventHandler(async () => {
+  return { id: 1, name: 'Gauranga' }
+})

--- a/test/withPerRouteLimit.test.ts
+++ b/test/withPerRouteLimit.test.ts
@@ -1,0 +1,46 @@
+import { fileURLToPath } from 'node:url'
+import { rm } from 'node:fs/promises'
+import { describe, it, expect, beforeEach } from 'vitest'
+import { setup, $fetch } from '@nuxt/test-utils/e2e'
+import type { ApiResponse } from './ApiResponse'
+
+describe('shield with /api/example-specific-limit route', async () => {
+  beforeEach(async () => {
+    const storagePath = fileURLToPath(new URL('../_testWithRoutesLimiteShield', import.meta.url))
+    await rm(storagePath, { recursive: true, force: true })
+  })
+
+  await setup({
+    rootDir: fileURLToPath(new URL('./fixtures/withPerRouteLimit', import.meta.url)),
+  })
+
+  it('respond to api call 1 times (limit.max, limit.duration) and rejects the 2nd call', async () => {
+    /**
+     * Make a request to default limited route
+     */
+    await $fetch('/api/example?c=1/1', {
+      method: 'GET',
+      retryStatusCodes: [],
+    })
+
+    const response = await $fetch('/api/example-specific-limit?c=1/2', {
+      method: 'GET',
+      retryStatusCodes: [],
+    })
+    expect((response as ApiResponse).name).toBe('Radha')
+
+    try {
+      // as limit.max = 1, this should throw 429 and ban for 2 seconds (limit.ban)
+      // this limit is defined in route configuration
+      await expect(async () =>
+        $fetch('/api/example-specific-limit?c=2/2', { method: 'GET', retryStatusCodes: [] }),
+      ).rejects.toThrowError()
+    }
+    catch (err) {
+      const typedErr = err as { statusCode: number, statusMessage: string }
+      console.log(err)
+      expect(typedErr.statusCode).toBe(429)
+      expect(typedErr.statusMessage).toBe('Leave me alone')
+    }
+  })
+})


### PR DESCRIPTION
## per-route rate limiting feature

- [x] Added support for mixed `routes` configuration (`string` and `{ path, max, duration }`)
- [x] Implemented per-route request counting (each route maintains its own counter)
- [x] Ensured that global fallback limits still apply when no specific route matches
- [x] Preserved **global ban behavior** — exceeding any limit will ban the IP across all routes
- [x] Introduced per-route/IP storage keys to avoid counter collisions between endpoints
- [x] Added E2E tests
- [x] Added documentation explaining how to use per-route limits

The following documentation section has been added to the README:

```md
## Per-Route Rate Limiting

`nuxt-api-shield` supports **per-route rate limiting**, allowing you to define custom limits for specific API endpoints while keeping a global default configuration for all other routes.

This is useful when certain endpoints (such as `/api/login`, `/api/auth`, or `/api/payment`) require stricter protection.

### Configuration Example

The `routes` option accepts a mixed array:

- **String:** applies the global rate limit configuration
- **Object:** applies custom per-route limits

```ts
export default defineNuxtConfig({
  nuxtApiShield: {
    limit: {
      max: 12,
      duration: 108,
      ban: 3600
    },

    routes: [
      // String → uses global defaults
      '/api/example',

      // Object → custom limit for this route
      {
        path: '/api/example-per-route',
        max: 5,
        duration: 10
        // "ban" remains global
      }
    ],
  }
})
```

Feel free to share any thoughts or adjustments